### PR TITLE
try reducing assumptions for closing game; minimise cases in solver

### DIFF
--- a/checkmate
+++ b/checkmate
@@ -12,7 +12,7 @@ import logging
 from pickletools import optimize
 import sys
 from textwrap import shorten
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, Iterable, List, Set, Tuple
 import z3
 
 from auxfunz3 import Real, Boolean, negation, conjunction, disjunction, implication, minimize, simplify_boolean
@@ -72,8 +72,10 @@ class StrategySolver(metaclass=ABCMeta):
         otherwise, returns a solution to report later
         """
 
-        result = {"generated_preconditions": list(self._generated_preconditions),
-                  "cases": []}
+        result = {
+            "generated_preconditions": list(self._generated_preconditions),
+            "cases": []
+        }
         # a solver that manages case splits, AVATAR style
         case_solver = z3.Solver()
         # it should know about initial constraints for the property we're trying
@@ -104,7 +106,7 @@ class StrategySolver(metaclass=ABCMeta):
                     return right > left
 
             # the current case is the conjunction of all known expression comparisons
-            case = [
+            case = {
                 split(left, right)
                 for left, right in itertools.chain(
                     itertools.combinations(reals, 2),
@@ -112,11 +114,22 @@ class StrategySolver(metaclass=ABCMeta):
                 )
                 # no point in providing e.g. 2.0 > 1.0
                 if type(left) != float or type(right) != float
-            ]
+            }
             logging.info(f"current case assumes {case}")
 
             if self._solver.check(self._property_constraint(case)) == z3.sat:
-                logging.info("case solved")
+                logging.info("case solved, minimising...")
+                remove = set()
+                for split in case:
+                    logging.info(f"trying to remove {split}...")
+                    if self._solver.check(self._property_constraint(case - remove - {split})) == z3.sat:
+                        remove.add(split)
+                        logging.info(f"{split} unnecessary, removed")
+                    else:
+                        logging.info(f"{split} necessary, retained")
+
+                case = case - remove
+                logging.info(f"final case is {case}")
                 if output:
                     result["cases"].append(self._extract_strategy(case))
 
@@ -216,7 +229,7 @@ class StrategySolver(metaclass=ABCMeta):
                 checked_history[:i], checked_history[i]
             ))
 
-    def _property_constraint(self, case: List[Boolean]) -> z3.BoolRef:
+    def _property_constraint(self, case: Iterable[Boolean]) -> z3.BoolRef:
         """
         create a universally-quantified constraint for a given property of the form
         ```
@@ -278,7 +291,7 @@ class StrategySolver(metaclass=ABCMeta):
         assert isinstance(expr, z3.BoolRef)
         return expr
 
-    def _extract_strategy(self, case: List[z3.BoolRef]) -> Dict[str, Any]:
+    def _extract_strategy(self, case: Iterable[z3.BoolRef]) -> Dict[str, Any]:
         """Extracting strategies from the solver for the current case split."""
         strategy = {}
         model = self._solver.model()

--- a/examples/closing_game.json
+++ b/examples/closing_game.json
@@ -41,12 +41,7 @@
     "d_A > 0",
     "d_B > 0",
     "p_A > 0",
-    "p_B > 0",
-    "a >= d_B",
-    "b >= d_A",
-    "a >= p_B",
-    "b >= p_A",
-    "b >= c"
+    "p_B > 0"
   ],
   "property_constraints": {
     "weak_immunity": [


### PR DESCRIPTION
I tried removing some assumptions in a random fashion from the closing game input. It turns out that the infinitesimal constraints are all necessary, but that some of the others are not. However, removing these constraints significantly increases the number of case splits required - when I reached 525 (!) I stopped, but I could imagine that more could be removed in exchange for even more case splits.

I wondered if the number of splits could be reduced by weakening the assumptions of the current case split and seeing if there was still a solution. It can (525 -> 52), but it's quite expensive.

I'm don't think either of these changes want to be in the mainline, but you may find them interesting.